### PR TITLE
[Database]: Groups & GroupUser Sequelize Model

### DIFF
--- a/backend/migrations/20240216191115-create-group.js
+++ b/backend/migrations/20240216191115-create-group.js
@@ -1,0 +1,57 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('groups', {
+      group_id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      task_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      extension: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      gitlab_group_id: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      gitlab_project_id: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      gitlab_url: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+
+    await queryInterface.addConstraint('groups', {
+      fields: ['task_id'],
+      type: 'foreign key',
+      name: 'fkey_task_id',
+      references: {
+        table: 'tasks',
+        field: 'id',
+      },
+      onDelete: 'RESTRICT',
+      onUpdate: 'RESTRICT',
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('groups');
+  }
+};

--- a/backend/migrations/20240220204707-create-group-user.js
+++ b/backend/migrations/20240220204707-create-group-user.js
@@ -1,0 +1,65 @@
+'use strict';
+const { DataTypes } = require("sequelize");
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('group_user', {
+      task_id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true
+      },
+      username: {
+        type: Sequelize.STRING,
+        primaryKey: true
+      },
+      group_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      status: {
+        type: Sequelize.ENUM('confirmed', 'pending'),
+        allowNull: false
+      }
+    });
+
+    await queryInterface.addConstraint('group_user', {
+      fields: ['task_id'],
+      type: 'foreign key',
+      name: 'fkey_task_id',
+      references: {
+        table: 'tasks',
+        field: 'id',
+      },
+      onDelete: 'RESTRICT',
+      onUpdate: 'RESTRICT',
+    });
+
+    await queryInterface.addConstraint('group_user', {
+      fields: ['group_id'],
+      type: 'foreign key',
+      name: 'fkey_group_id',
+      references: {
+        table: 'groups',
+        field: 'group_id',
+      },
+      onDelete: 'RESTRICT',
+      onUpdate: 'RESTRICT',
+    });
+
+    await queryInterface.addConstraint('group_user', {
+      fields: ['username'],
+      type: 'foreign key',
+      name: 'fkey_username_id',
+      references: {
+        table: 'user_info',
+        field: 'username',
+      },
+      onDelete: 'RESTRICT',
+      onUpdate: 'RESTRICT',
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('group_user');
+  }
+};

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -39,7 +39,7 @@ Group.init({
   }
 }, {
   sequelize,
-  modelName: 'groups',
+  modelName: 'Group',
 });
 
 

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -1,0 +1,46 @@
+'use strict';
+const { Model, DataTypes } = require('sequelize');
+const sequelize = require('../helpers/database');
+
+class Group extends Model {
+  static associate(models) {
+    Group.belongsTo(models.Task, {
+      onUpdate: 'RESTRICT',
+      onDelete: 'RESTRICT'
+    }); // foreignKey will default to the primary key of Task model
+  }
+}
+
+Group.init({
+  group_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  task_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  extension: {
+    type: DataTypes.INTEGER,
+    allowNull: true
+  },
+  gitlab_group_id: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  gitlab_project_id: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  gitlab_url: {
+    type: DataTypes.STRING,
+    allowNull: true
+  }
+}, {
+  sequelize,
+  modelName: 'groups',
+});
+
+
+module.exports = Group;

--- a/backend/models/group_user.js
+++ b/backend/models/group_user.js
@@ -1,0 +1,51 @@
+const { Model, DataTypes } = require('sequelize');
+const sequelize = require('../helpers/database');
+
+class GroupUser extends Model {
+  /**
+   * Helper method for defining associations.
+   * This method is not a part of Sequelize lifecycle.
+   * The `models/index` file will call this method automatically.
+   */
+  static associate(models) {
+    GroupUser.belongsTo(models.Group, {
+      onUpdate: 'RESTRICT',
+      onDelete: 'RESTRICT',
+    });
+
+    GroupUser.belongsTo(models.Task, {
+      onUpdate: 'RESTRICT',
+      onDelete: 'RESTRICT'
+    });
+
+    GroupUser.belongsTo(models.User, {
+      onUpdate: 'RESTRICT',
+      onDelete: 'RESTRICT'
+    })
+  }
+}
+
+GroupUser.init({
+  task_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+  },
+  username: {
+    type: DataTypes.STRING,
+    primaryKey: true,
+  },
+  group_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  status: {
+    type: DataTypes.ENUM('confirmed', 'pending'),
+    allowNull: false
+  }
+}, {
+  sequelize,
+  modelName: 'GroupUser',
+  timestamps: false
+});
+
+module.exports = GroupUser;


### PR DESCRIPTION
## Changes
- Created a sequelize model and migration file for groups table based off [this SQL statement](https://github.com/Kianoosh76/IBS/blob/852159ffed7619e834e5fb19f3dbb09b07570d25/backend/module/course/admin/add.js#L152) from `Admin > Add Course` endpoint
    - One thing in the new model that is different from the old table is that the foreign key to the tasks table is the `id` of the task rather than the tasks name. HOWEVER, this is not a huge issue because we can just account for this change in all the endpoints that deal with `groups`.
    - I thought that referring to the task via its `id` is better than its name because the database no longer enforces a different schema for every course. In the old version, it was assumed that every task had a unique name which made it an unenforced "primary key".
- Created a sequelize model and migration file for group_user table based off [this SQL statement](https://github.com/Kianoosh76/IBS/blob/852159ffed7619e834e5fb19f3dbb09b07570d25/backend/module/course/admin/add.js#L164) 

This is what I see when clicking "ERD For Table" on pgadmin. The main thing to note is the foreign key association between the `groups`, `group_user`, and `tasks` tables .

![image](https://github.com/Kianoosh76/IBS/assets/56232388/d4624d90-6c6d-4777-9e81-16bf0f566278)


## Manual Testing

- Run the following series of commands
```
git pull
git checkout refactor/groupsModel
docker system prune -a && docker volume rm $(docker volume ls -q)
make build && make run
```
- Open up pgadmin and check on the `ibs` database running at `localhost:5432` and then find `ibs > Schemas > Tables`.
    -  At this point you should see a `groups` and `group_user` relation
- Right click `groups` and select `ERD For Table`. You should see something similar to the screenshot above.